### PR TITLE
add calendars of divisions for international regions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -44,24 +44,30 @@ jobs:
           APPLICATION_NAME: "valorant-match-schedule"
           API_ENDPOINT_DOMAIN_NAME: ${{ secrets.API_ENDPOINT_DOMAIN_NAME }}
           GOOGLE_SERVICE_ACCOUNT_ID: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_ID }}
+          GCAL_ID_AMERICAS: ${{ vars.GCAL_ID_AMERICAS }}
+          GCAL_ID_CHINA: ${{ vars.GCAL_ID_CHINA }}
+          GCAL_ID_EMEA: ${{ vars.GCAL_ID_EMEA }}
+          GCAL_ID_PACIFIC: ${{ vars.GCAL_ID_PACIFIC }}
+          GCAL_ID_INTERNATIONAL: ${{ vars.GCAL_ID_INTERNATIONAL }}
           GCAL_ID_APAC: ${{ vars.GCAL_ID_APAC }}
           GCAL_ID_BR_LATAM: ${{ vars.GCAL_ID_BR_LATAM }}
           GCAL_ID_EAST_ASIA: ${{ vars.GCAL_ID_EAST_ASIA }}
-          GCAL_ID_EMEA: ${{ vars.GCAL_ID_EMEA }}
           GCAL_ID_NA: ${{ vars.GCAL_ID_NA }}
-          GCAL_ID_INTERNATIONAL: ${{ vars.GCAL_ID_INTERNATIONAL }}
         run: |
           tee params.json << EOF
           { 
             "ApplicationName": "${APPLICATION_NAME}",
             "APIEndpointDomainName": "${API_ENDPOINT_DOMAIN_NAME}",
             "GoogleServiceAccountId": "${GOOGLE_SERVICE_ACCOUNT_ID}",
+            "CalendarIdAmericas": "${GCAL_ID_AMERICAS}",
+            "CalendarIdChina": "${GCAL_ID_CHINA}",
+            "CalendarIdEmea": "${GCAL_ID_EMEA}",
+            "CalendarIdPacific": "${GCAL_ID_PACIFIC}",
+            "CalendarIdInternational": "${GCAL_ID_INTERNATIONAL}",
             "CalendarIdApac": "${GCAL_ID_APAC}",
             "CalendarIdBrLatam": "${GCAL_ID_BR_LATAM}",
             "CalendarIdEastAsia": "${GCAL_ID_EAST_ASIA}",
-            "CalendarIdEmea": "${GCAL_ID_EMEA}",
-            "CalendarIdNa": "${GCAL_ID_NA}",
-            "CalendarIdInternational": "${GCAL_ID_INTERNATIONAL}"
+            "CalendarIdNa": "${GCAL_ID_NA}"
           }
           EOF
       - name: Build SAM packages

--- a/README.md
+++ b/README.md
@@ -6,6 +6,24 @@ You can check worldwide VALORANT matches schedule in Google Calendar.
 
 https://valorant-calendar.mizt.ch/
 
+> [!TIP]
+> - All Calendars except `International` contain tier-1 and tier-2 matches played in the region.
+
+- [International](https://calendar.google.com/calendar/u/0?cid=ZjJiMjY1MTkwZmNkMDY5NjY5M2FiZjgwODE1OGRkZDQ1MTQwNjY1ZGRkMGM1YjM3YWFhYTA0ZGJjZDYxZWFhOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) : contains all VCT international matches and some community events.
+- [Americas](https://calendar.google.com/calendar/u/0?cid=YmRkZTBmNWZhYTQ2ZTQxZGRmYWJkZTJmYjhlZDZhZTcxOTdiNjQ2MTQyYjhlZDAzOTdmMGE0ZjBiYmQxMDlmNEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
+- [EMEA](https://calendar.google.com/calendar/u/0?cid=OWNjOGI0YmIwMjFiMDE5NGIyNDEzOWRiMjU1NjFmYTc0ZGVhYTc0MzU0YWY1NDkzMDFiNDRhZWNjOTJiMzJiOUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
+- [Pacific](https://calendar.google.com/calendar/u/0?cid=N2EzN2YxZmYzMzdiODBmOWRiOWFhOGVhNWQ2ZDBiYWY5ODE4MDM0YmIyMDhiNDAyNWUzNDFjNGE3NTMyMTE5OUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
+- [China](https://calendar.google.com/calendar/u/0?cid=ODFhYjAxZTQ1ZmNiNGY5MjViNzZmOTdmYjA0MjA3Mjc3MjUxZjhhM2FhMDUyMGYxMDA3MmUzYzBhMjQyMTdjNEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
+
+> [!WARNING]
+> - Below are scheduled to be de-updated or removed in the near future
+> - I recommend that you replace each of them by subscribing to a new calendar that will replace it.
+
+- [NA](https://calendar.google.com/calendar/u/0?cid=NDg2OTg5YjJjYTEwZTk5OGVlODU4YTcyMDRiMTNjZDkzNWQ0MTFmMjlkYzA4MzA1ZGJiZDFjNDIzN2YyYTIxZEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) : All events in this calendar are also included in `Americas`.
+- [Brazil / LATAM](https://calendar.google.com/calendar/u/0?cid=NTNjYTg1NDZhNGQzM2IzMTkzNmVkMjA0NjE2NmY2OTA2ODc1YzhiMzM3N2JhOThiOWFkMWJhZjNhMDQwZjA3NUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) : All events in this calendar are also included in `Americas`.
+- [APAC](https://calendar.google.com/calendar/u/0?cid=YTZiOWM3ZGI5YzdmM2U2YjFmNjNmMjc4MjhkMzM0ZjQ0NTFhZDI0ZGU1NzA0YjI4YTk5YzU1ZGEwNjk5YjdiZkBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) : All events in this calendar are also included in `Pacific`.
+- [East Asia](https://calendar.google.com/calendar/u/0?cid=MWEyMWYzYWFlMDRjYWJiODQxNDFlOGE1ZjRhYTRjZTA4NWNmMzZlNDA0YjQyOGIzYjZjNzYxMWE4MTllZjczMkBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) : All events in this calendar are also included in `Pacific`.
+
 ## Architecture overview
 ![architecture](image/valorant-match-schedule.drawio.svg)
 
@@ -25,7 +43,7 @@ If you want to do it yourself, you should be ready with:
     cp service_account_key.json valorant-match-schedule/add-gcal-event/function/service_account_key.json
     ```
 - calendars and their ids for each regions: see [here](https://docs.simplecalendar.io/find-google-calendar-id/)
-  - 6 calendars are needed. (for `EMEA`, `NA`, `BR/LATAM`, `APAC`, `EAST_ASIA`, `INTERNATIONAL`)
+  - 9 calendars are needed for each regions.
 
 ## Provisioning
 

--- a/function/fetch-daily-matches/constants.py
+++ b/function/fetch-daily-matches/constants.py
@@ -134,7 +134,7 @@ international_events = [
     "Champions Tour 2024: EMEA Stage 2",
     "Champions Tour 2024: Pacific Stage 2",
     "Champions Tour 2024: China Stage 2",
-    "Valorant Champions 2024"
+    "Valorant Champions 2024",
 ]
 
 abbrs = {

--- a/function/fetch-daily-matches/constants.py
+++ b/function/fetch-daily-matches/constants.py
@@ -1,3 +1,12 @@
+tier1_regions = {
+    "NA": "AMERICAS",
+    "BR_LATAM": "AMERICAS",
+    "APAC": "PACIFIC",
+    "EAST_ASIA": "PACIFIC",
+    "CHINA": "CHINA",
+    "EMEA": "EMEA",
+}
+
 countries = {
     "ar": "BR_LATAM",
     "at": "EMEA",
@@ -9,7 +18,7 @@ countries = {
     "ca": "NA",
     "ch": "EMEA",
     "cl": "BR_LATAM",
-    "cn": "EAST_ASIA",
+    "cn": "CHINA",
     "co": "BR_LATAM",
     "cz": "EMEA",
     "de": "EMEA",

--- a/template.yaml
+++ b/template.yaml
@@ -14,17 +14,23 @@ Parameters:
     ConstraintDescription: should be appropriate domain format
   GoogleServiceAccountId:
     Type: String
+  CalendarIdAmericas:
+    Type: String
+  CalendarIdChina:
+    Type: String
+  CalendarIdEmea:
+    Type: String
+  CalendarIdPacific:
+    Type: String
+  CalendarIdInternational:
+    Type: String
   CalendarIdApac:
     Type: String
   CalendarIdBrLatam:
     Type: String
   CalendarIdEastAsia:
     Type: String
-  CalendarIdEmea:
-    Type: String
   CalendarIdNa:
-    Type: String
-  CalendarIdInternational:
     Type: String
   ScheduleExpression:
     Description: schedule expression for the eventbridge event
@@ -98,12 +104,15 @@ Resources:
         Variables:
           OUTBOX_TABLE: !Ref OutboxTable
           GOOGLE_SERVICE_ACCOUNT_ID: !Ref GoogleServiceAccountId
+          CALENDAR_ID_AMERICAS: !Ref CalendarIdAmericas
+          CALENDAR_ID_CHINA: !Ref CalendarIdChina
+          CALENDAR_ID_EMEA: !Ref CalendarIdEmea
+          CALENDAR_ID_PACIFIC: !Ref CalendarIdPacific
+          CALENDAR_ID_INTERNATIONAL: !Ref CalendarIdInternational
           CALENDAR_ID_APAC: !Ref CalendarIdApac
           CALENDAR_ID_BR_LATAM: !Ref CalendarIdBrLatam
           CALENDAR_ID_EAST_ASIA: !Ref CalendarIdEastAsia
-          CALENDAR_ID_EMEA: !Ref CalendarIdEmea
           CALENDAR_ID_NA: !Ref CalendarIdNa
-          CALENDAR_ID_INTERNATIONAL: !Ref CalendarIdInternational
       Layers:
         - !Ref GoogleAuthLayer
         - !Ref GoogleApiPythonClientLayer


### PR DESCRIPTION
- add calendar for Americas, China, Pacific
  - these include both tier-1 and tier-2 matches
- matches in China are removed from East Asia / Pacific calendars.
- added public URLs on README