### PR TITLE
fix: skip failed match scraping and fix pagination logic

### DIFF
--- a/cmd/scrape/main.go
+++ b/cmd/scrape/main.go
@@ -15,8 +15,14 @@ type Payload struct {
 	Page int `json:"page"`
 }
 
+type MatchesSummary struct {
+	Total     int `json:"total"`
+	Succeeded int `json:"succeeded"`
+	Failed    int `json:"failed"`
+}
+
 type Response struct {
-	MatchesCount int `json:"matches_count"`
+	Matches MatchesSummary `json:"matches"`
 }
 
 // Handler processes match scraping and outputs to SQS
@@ -33,7 +39,7 @@ func Handler(ctx context.Context, payload Payload) (string, error) {
 	eventRepo := infrastructure.NewEventRepository(infrastructure.NewVlrGGScraper(), infrastructure.NewEventCache())
 	app := application.NewMatchService(matchRepo, eventRepo)
 
-	matches, err := app.FetchMatches(payload.Page)
+	matches, matchURLsCount, err := app.FetchMatches(payload.Page)
 	if err != nil {
 		slog.Error("failed to fetch matches", "error", err.Error())
 		return "", err
@@ -47,7 +53,13 @@ func Handler(ctx context.Context, payload Payload) (string, error) {
 	}
 	slog.Info("Successfully sent matches to SQS", "matchCount", len(matches))
 
-	response := Response{MatchesCount: len(matches)}
+	response := Response{
+		Matches: MatchesSummary{
+			Total:     matchURLsCount,
+			Succeeded: len(matches),
+			Failed:    matchURLsCount - len(matches),
+		},
+	}
 	r, _ := json.Marshal(response)
 
 	return string(r), nil

--- a/internal/application/match_scraping_service.go
+++ b/internal/application/match_scraping_service.go
@@ -20,14 +20,12 @@ func NewMatchService(matchRepo domain.MatchRepository, eventRepo domain.EventRep
 	}
 }
 
-func (svc *MatchService) FetchMatches(page int) ([]domain.Match, error) {
+func (svc *MatchService) FetchMatches(page int) ([]domain.Match, int, error) {
 	slog.Info("Starting to fetch matches", "page", page)
 
-	// Implement match fetching logic
 	matchURLs, err := svc.matchRepo.GetMatchURLList(page)
 	if err != nil {
-		slog.Error("Failed to get match URLs", "error", err.Error(), "page", page)
-		return nil, fmt.Errorf("failed to get match urls: %w", err)
+		return nil, 0, fmt.Errorf("failed to get match urls: %w", err)
 	}
 
 	slog.Info("Retrieved match URLs", "count", len(matchURLs), "page", page)
@@ -36,11 +34,10 @@ func (svc *MatchService) FetchMatches(page int) ([]domain.Match, error) {
 	for i, matchURL := range matchURLs {
 		m, err := svc.matchRepo.ScrapeMatch(matchURL)
 		if err != nil {
-			slog.Error("Failed to scrape match", "error", err.Error(), "matchURL", matchURL, "index", i)
-			return nil, fmt.Errorf("failed to get match: %w", err)
+			slog.Warn("Failed to scrape match, skipping", "error", err.Error(), "matchURL", matchURL, "index", i)
+			continue
 		}
 
-		// Check if the scraped match is empty
 		if domain.IsEmptyVlrMatch(m) {
 			slog.Warn("Skipping empty match", "matchURL", matchURL, "index", i)
 			continue
@@ -50,8 +47,8 @@ func (svc *MatchService) FetchMatches(page int) ([]domain.Match, error) {
 
 		e, err := svc.eventRepo.GetEvent(m.EventPagePath)
 		if err != nil {
-			slog.Error("Failed to get event", "error", err.Error(), "eventPath", m.EventPagePath, "matchId", m.Id)
-			return nil, fmt.Errorf("failed to get event: %w", err)
+			slog.Warn("Failed to get event, skipping", "error", err.Error(), "eventPath", m.EventPagePath, "matchId", m.Id)
+			continue
 		}
 
 		match := domain.NewMatch(m, e)
@@ -66,17 +63,15 @@ func (svc *MatchService) FetchMatches(page int) ([]domain.Match, error) {
 		matches = append(matches, match)
 	}
 
-	slog.Info("Successfully fetched matches", "totalCount", len(matches), "page", page)
-	return matches, nil
+	slog.Info("Successfully fetched matches", "totalCount", len(matches), "urlCount", len(matchURLs), "page", page)
+	return matches, len(matchURLs), nil
 }
 
 func (svc *MatchService) WriteMatches(ctx context.Context, matches []domain.Match) error {
 	slog.Info("Writing matches to repository", "count", len(matches))
 
-	// Implement match writing logic
 	err := svc.matchRepo.WriteMatches(ctx, matches)
 	if err != nil {
-		slog.Error("Failed to write matches", "error", err.Error(), "count", len(matches))
 		return fmt.Errorf("failed to write matches: %w", err)
 	}
 

--- a/statemachine/scraping.asl.json
+++ b/statemachine/scraping.asl.json
@@ -6,29 +6,9 @@
             "Type": "Pass",
             "Parameters": {
                 "currentPage": 1,
-                "maxPages": 10,
-                "shouldContinue": true
+                "maxPages": 10
             },
-            "Next": "Check Continue Condition"
-        },
-        "Check Continue Condition": {
-            "Type": "Choice",
-            "Choices": [
-                {
-                    "And": [
-                        {
-                            "Variable": "$.shouldContinue",
-                            "BooleanEquals": true
-                        },
-                        {
-                            "Variable": "$.currentPage",
-                            "NumericLessThanEqualsPath": "$.maxPages"
-                        }
-                    ],
-                    "Next": "Wait Before Scraping"
-                }
-            ],
-            "Default": "Execution Complete"
+            "Next": "Wait Before Scraping"
         },
         "Wait Before Scraping": {
             "Type": "Wait",
@@ -65,50 +45,52 @@
                 "lambdaResult.$": "$.lambdaResult",
                 "parsedOutput.$": "States.StringToJson($.lambdaResult)"
             },
-            "Next": "Check Matches Count"
+            "Next": "Check Continue Condition"
         },
-        "Check Matches Count": {
+        "Check Continue Condition": {
             "Type": "Choice",
             "Choices": [
                 {
-                    "Variable": "$.parsedOutput.matches_count",
-                    "NumericLessThan": 50,
-                    "Next": "Stop Processing"
+                    "And": [
+                        {
+                            "Variable": "$.parsedOutput.matches.total",
+                            "NumericGreaterThanEquals": 50
+                        },
+                        {
+                            "Variable": "$.currentPage",
+                            "NumericLessThanPath": "$.maxPages"
+                        }
+                    ],
+                    "Next": "Continue Processing"
                 }
             ],
-            "Default": "Continue Processing"
+            "Default": "Stop Processing"
         },
         "Continue Processing": {
             "Type": "Pass",
             "Parameters": {
                 "currentPage.$": "States.MathAdd($.currentPage, 1)",
                 "maxPages.$": "$.maxPages",
-                "shouldContinue": true,
                 "lastResult.$": "$.lambdaResult",
-                "lastMatchesCount.$": "$.parsedOutput.matches_count"
+                "lastMatchesCount.$": "$.parsedOutput.matches.total"
             },
-            "Next": "Check Continue Condition"
+            "Next": "Wait Before Scraping"
         },
         "Stop Processing": {
             "Type": "Pass",
             "Parameters": {
-                "currentPage.$": "$.currentPage",
-                "maxPages.$": "$.maxPages",
-                "shouldContinue": false,
-                "terminationReason": "matches_count was less than 50",
-                "finalMatchesCount.$": "$.parsedOutput.matches_count",
+                "totalPagesProcessed.$": "$.currentPage",
+                "finalMatchesCount.$": "$.parsedOutput.matches.total",
                 "lastResult.$": "$.lambdaResult"
             },
-            "Next": "Check Continue Condition"
+            "Next": "Execution Complete"
         },
         "Execution Complete": {
             "Type": "Pass",
             "Parameters": {
-                "totalPagesProcessed.$": "States.MathAdd($.currentPage, -1)",
-                "terminationReason.$": "$.terminationReason",
+                "totalPagesProcessed.$": "$.totalPagesProcessed",
                 "finalMatchesCount.$": "$.finalMatchesCount",
-                "lastResult.$": "$.lastResult",
-                "completionReason.$": "States.Format('Loop completed. shouldContinue: {}, currentPage: {}, maxPages: {}', $.shouldContinue, $.currentPage, $.maxPages)"
+                "lastResult.$": "$.lastResult"
             },
             "End": true
         }


### PR DESCRIPTION
- FetchMatches: continue on individual match/event scrape failures instead of aborting the page, and return URL count alongside matches
- Response: restructure to `{"matches": {"total", "succeeded", "failed"}}` to separate URL count (for pagination) from successfully scraped count
- State machine: simplify loop control with a single `Check Continue Condition` using AND, drop `shouldContinue` flag and `terminationReason`